### PR TITLE
dependencies: move lpips import into function

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ All details related to installation and logic are described in the
 
 Some of the functionalities of `atlalign` depend on the [TensorFlow implementation
 of the Learned Perceptual Image Patch Similarity (LPIPS)](https://github.com/alexlee-gk/lpips-tensorflow). Unfortunately, the
-package is not available on PyPI and must be installed manually as follows.
+package is not available on PyPI and must be installed manually as follows
+for full functionality.
 ```shell script
 pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
 ```

--- a/atlalign/metrics.py
+++ b/atlalign/metrics.py
@@ -37,7 +37,6 @@ should always return a tuple of (metric_average, metric_per_output).
 from functools import wraps
 
 import ants
-
 import numpy as np
 import pandas as pd
 import tensorflow as tf

--- a/atlalign/metrics.py
+++ b/atlalign/metrics.py
@@ -38,18 +38,6 @@ from functools import wraps
 
 import ants
 
-try:
-    import lpips_tf
-except ModuleNotFoundError as err:
-    raise ModuleNotFoundError(
-        """
-        LPIPS-TensorFlow required but not found.
-
-        Please install it by running the following command:
-        $ pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
-        """
-    ) from err
-
 import numpy as np
 import pandas as pd
 import tensorflow as tf
@@ -996,6 +984,17 @@ def perceptual_loss_img(y_true, y_pred, model="net-lin", net="vgg"):
     We use the decorator just to make sure we do not run out of memory during a forward pass. Also,
     its fully convolutional but if the images are too small then might run into issues.
     """
+    try:
+        import lpips_tf
+    except ModuleNotFoundError as err:
+        raise ModuleNotFoundError(
+            """
+            LPIPS-TensorFlow required but not found.
+
+            Please install it by running the following command:
+            $ pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
+            """
+        ) from err
     # gray2rgb
     y_true = np.stack((y_true,) * 3, axis=-1)
     y_pred = np.stack((y_pred,) * 3, axis=-1)

--- a/atlalign/ml_utils/losses.py
+++ b/atlalign/ml_utils/losses.py
@@ -22,18 +22,6 @@
 import tensorflow.keras.backend as K
 from tensorflow import keras
 
-try:
-    import lpips_tf
-except ModuleNotFoundError as err:
-    raise ModuleNotFoundError(
-        """
-        LPIPS-TensorFlow required but not found.
-
-        Please install it by running the following command:
-        $ pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
-        """
-    ) from err
-
 import numpy as np
 import tensorflow as tf
 
@@ -157,6 +145,17 @@ class PerceptualLoss:
 
     def loss(self, y_true, y_pred):
         """Compute loss."""
+        try:
+            import lpips_tf
+        except ModuleNotFoundError as err:
+            raise ModuleNotFoundError(
+                """
+                LPIPS-TensorFlow required but not found.
+
+                Please install it by running the following command:
+                $ pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
+                """
+            ) from err
         y_true_rgb = tf.concat(3 * [y_true], axis=-1)
         y_pred_rgb = tf.concat(3 * [y_pred], axis=-1)
 

--- a/atlalign/ml_utils/losses.py
+++ b/atlalign/ml_utils/losses.py
@@ -19,11 +19,10 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-import tensorflow.keras.backend as K
-from tensorflow import keras
-
 import numpy as np
 import tensorflow as tf
+import tensorflow.keras.backend as K
+from tensorflow import keras
 
 
 # IMAGE LOSSES


### PR DESCRIPTION
This makes the lpips functionality somewhat optional by moving the
import from the module scope into the function where it is used.  Should
simplify installation.
