### PR TITLE
Add optional lpips dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,30 +76,31 @@ All details related to installation and logic are described in the
 
 ### Installation
 
-#### Installation Requirements
-
-Some of the functionalities of `atlalign` depend on the [TensorFlow implementation
-of the Learned Perceptual Image Patch Similarity (LPIPS)](https://github.com/alexlee-gk/lpips-tensorflow). Unfortunately, the
-package is not available on PyPI and must be installed manually as follows
-for full functionality.
-```shell script
-pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
-```
-
-You can now move on to installing the actual `atlalign` package!
-
 #### Installation from PyPI
 The `atlalign` package can be easily installed from PyPI.
 ```shell script
 pip install atlalign
 ```
 
+If you need to use the functionalities depending on the [TensorFlow implementation
+of the Learned Perceptual Image Patch Similarity (LPIPS)](https://github.com/alexlee-gk/lpips-tensorflow),
+you should use instead:
+```shell script
+pip install 'atlalign[lpips]'
+```
+
 #### Installation from source
 As an alternative to installing from PyPI, if you want to try the latest version
 you can also install from source. 
 ```shell script
-pip install git+https://github.com/BlueBrain/atlas_alignment#egg=atlalign
+pip install 'git+https://github.com/BlueBrain/atlas_alignment#egg=atlalign'
 ```
+
+or, to include the LPIPS dependency:
+```shell script
+pip install 'git+https://github.com/BlueBrain/atlas_alignment#egg=atlalign[lpips]'
+```
+
 
 #### Installation for development
 If you want a dev install, you should install the latest version from source with
@@ -107,7 +108,7 @@ all the extra requirements for running test and generating docs.
 ```shell script
 git clone https://github.com/BlueBrain/atlas_alignment
 cd atlas_alignment
-pip install -e .[dev,docs]
+pip install -e '.[dev,docs,lpips]'
 ```
 
 ### Examples

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,19 +10,6 @@ The project is only available for **Python 3.7**. The main reason for this
 restriction is an external dependency **ANTsPy** that does
 not provide many precompiled wheels on PyPI.
 
-External Dependencies
----------------------
-Some of the functionalities of :code:`atlalign` depend on the
-`TensorFlow implementation of the Learned Perceptual Image Patch Similarity <https://github.com/alexlee-gk/lpips-tensorflow>`_.
-Unfortunately, the
-package is not available on PyPI and must be installed manually as follows.
-
-.. code-block:: bash
-
-    pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
-
-You can now move on to installing the actual `atlalign` package!
-
 Installation from PyPI
 ----------------------
 The :code:`atlalign` package can be easily installed from PyPI.
@@ -31,6 +18,14 @@ The :code:`atlalign` package can be easily installed from PyPI.
 
     pip install atlalign
 
+If you need to use the functionalities depending on the
+`TensorFlow implementation of the Learned Perceptual Image Patch Similarity <https://github.com/alexlee-gk/lpips-tensorflow>`_,
+you should use instead:
+
+.. code-block:: bash
+
+    pip install 'atlalign[lpips]'
+
 Installation from source
 ------------------------
 As an alternative to installing from PyPI, if you want to try the latest version
@@ -38,7 +33,13 @@ you can also install from source.
 
 .. code-block:: bash
 
-    pip install git+https://github.com/BlueBrain/atlas_alignment#egg=atlalign
+    pip install 'git+https://github.com/BlueBrain/atlas_alignment#egg=atlalign'
+
+or, to include the LPIPS dependency:
+
+.. code-block:: bash
+
+    pip install 'git+https://github.com/BlueBrain/atlas_alignment#egg=atlalign[lpips]'
 
 Development installation
 ------------------------
@@ -47,12 +48,13 @@ following way:
 
 - **dev** - pytest + plugins, flake8, pydocstyle, tox
 - **docs** - sphinx
+- **lpips** - lpips
 
 .. code-block:: bash
 
     git clone https://github.com/BlueBrain/atlas_alignment
     cd atlas_alignment
-    pip install -e .[dev,docs]
+    pip install -e '.[dev,docs,lpips]'
 
 
 Generating documentation

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,9 @@ setup(
             "pytest-mock>=1.10.1",
         ],
         "docs": ["sphinx>=1.3", "sphinx-bluebrain-theme"],
+        "lpips": [
+            "lpips_tf@git+https://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf",
+        ],
     },
     entry_points={"console_scripts": ["label-tool = atlalign.label.cli:main"]},
 )


### PR DESCRIPTION
Now the `lpips` dependency seems optional, but I'm opening this PR anyway because in `gene-expression-volume` we needed to explicitly install `lpips` to avoid an import error with the version `0.6.0` of `atlalign`.
Feel free to adopt the changes if useful, or modify them if needed.